### PR TITLE
Tomcat JNDI with JMS and workaround for lookups in non-Tomcat threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 .project
 .settings/
 .springBeans
+.idea/
+*.iml
 target

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.3.0.RELEASE</version>
+		<version>1.5.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -23,10 +23,20 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-activemq</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>tomcat-dbcp</artifactId>
 			<version>${tomcat.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.activemq</groupId>
+			<artifactId>activemq-broker</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/sample/tomcat/jndi/SampleTomcatJndiApplication.java
+++ b/src/main/java/sample/tomcat/jndi/SampleTomcatJndiApplication.java
@@ -16,48 +16,19 @@
 
 package sample.tomcat.jndi;
 
-import javax.naming.NamingException;
-import javax.sql.DataSource;
-
-import org.apache.catalina.Context;
-import org.apache.catalina.startup.Tomcat;
-import org.apache.tomcat.util.descriptor.web.ContextResource;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer;
-import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.jndi.JndiObjectFactoryBean;
+
+import javax.naming.NamingException;
+import javax.sql.DataSource;
 
 @SpringBootApplication
 public class SampleTomcatJndiApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(SampleTomcatJndiApplication.class, args);
-	}
-
-	@Bean
-	public TomcatEmbeddedServletContainerFactory tomcatFactory() {
-		return new TomcatEmbeddedServletContainerFactory() {
-
-			@Override
-			protected TomcatEmbeddedServletContainer getTomcatEmbeddedServletContainer(
-					Tomcat tomcat) {
-				tomcat.enableNaming();
-				return super.getTomcatEmbeddedServletContainer(tomcat);
-			}
-
-			@Override
-			protected void postProcessContext(Context context) {
-				ContextResource resource = new ContextResource();
-				resource.setName("jdbc/myDataSource");
-				resource.setType(DataSource.class.getName());
-				resource.setProperty("driverClassName", "your.db.Driver");
-				resource.setProperty("url", "jdbc:yourDb");
-
-				context.getNamingResources().addResource(resource);
-			}
-		};
 	}
 
 	@Bean(destroyMethod="")

--- a/src/main/java/sample/tomcat/jndi/config/EmbeddedTomcatConfig.java
+++ b/src/main/java/sample/tomcat/jndi/config/EmbeddedTomcatConfig.java
@@ -1,0 +1,106 @@
+package sample.tomcat.jndi.config;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.command.ActiveMQQueue;
+import org.apache.activemq.command.ActiveMQTopic;
+import org.apache.activemq.jndi.JNDIReferenceFactory;
+import org.apache.catalina.Context;
+import org.apache.catalina.startup.Tomcat;
+import org.apache.tomcat.util.descriptor.web.ContextResource;
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer;
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+/**
+ * This would be tuned off (probably using profiles) if this app would need need to be build as WAR and
+ * deployed to an external Servlet or Application Container with pre-configured JNDI resources.
+ * In that case all JNDI names and resources looked up by them would remain the same for this app's new
+ * code as well as legacy code.
+ */
+@Configuration
+public class EmbeddedTomcatConfig {
+
+	@Bean
+	public TomcatEmbeddedServletContainerFactory tomcatFactory() {
+		return new TomcatEmbeddedServletContainerFactory() {
+
+			@Override
+			protected TomcatEmbeddedServletContainer getTomcatEmbeddedServletContainer(Tomcat tomcat) {
+				tomcat.enableNaming();
+				return super.getTomcatEmbeddedServletContainer(tomcat);
+			}
+
+			@Override
+			protected void postProcessContext(Context context) {
+                context.getNamingResources().addResource(createDataSource());
+				context.getNamingResources().addResource(createJmsConnectionFactory());
+				context.getNamingResources().addResource(createJmsQueue());
+				context.getNamingResources().addResource(createJmsTopic());
+			}
+
+            private ContextResource createDataSource() {
+                ContextResource resource = new ContextResource();
+                resource.setName("jdbc/myDataSource");
+                resource.setType(DataSource.class.getName());
+                resource.setProperty("driverClassName", "your.db.Driver");
+                resource.setProperty("url", "jdbc:yourDb");
+                return resource;
+            }
+
+            /**
+             * To quickly add some JMS using ActiveMQ roughly based on http://activemq.apache.org/tomcat.html
+             *
+             * <Resource  name=”jms/ConnectionFactory” auth=”Container” type=”org.apache.activemq.ActiveMQConnectionFactory”
+             * description=”JMS Connection Factory” factory=”org.apache.activemq.jndi.JNDIReferenceFactory”
+             * brokerURL=”tcp://localhost:61616″ brokerName=”ActiveMQBroker” useEmbeddedBroker=”false”/>
+             */
+			private ContextResource createJmsConnectionFactory() {
+				ContextResource resource = new ContextResource();
+				resource.setName("jms/ConnectionFactory");
+				resource.setAuth("Container");
+				resource.setType(ActiveMQConnectionFactory.class.getName());
+				resource.setDescription("JMS Connection Factory");
+				resource.setProperty("factory", JNDIReferenceFactory.class.getName());
+				resource.setProperty("brokerName", "ActiveMQBroker");
+//				resource.setProperty("useEmbeddedBroker", "false");
+//				resource.setProperty("brokerURL", "tcp://localhost:61616");
+				resource.setProperty("useEmbeddedBroker", "true");
+				resource.setProperty("brokerURL", "vm://localhost?broker.persistent=false");
+                return resource;
+			}
+
+            /**
+             * <Resource name=”jms/topic/MyTopic” auth=”Container” type=”org.apache.activemq.command.ActiveMQTopic”
+             * factory=”org.apache.activemq.jndi.JNDIReferenceFactory” physicalName=”APP.JMS.TOPIC”/>
+             */
+            private ContextResource createJmsTopic() {
+                ContextResource resource = new ContextResource();
+                resource.setName("jms/topic/MyTopic");
+                resource.setAuth("Container");
+                resource.setType(ActiveMQTopic.class.getName());
+                resource.setProperty("factory", JNDIReferenceFactory.class.getName());
+                resource.setProperty("physicalName", "APP.JMS.TOPIC");
+                return resource;
+            }
+
+			/**
+			 * <Resource name=”jms/queue/MyQueue” auth=”Container” type=”org.apache.activemq.command.ActiveMQQueue”
+			 * factory=”org.apache.activemq.jndi.JNDIReferenceFactory” physicalName=” APP.JMS.QUEUE “/>
+			 */
+			private ContextResource createJmsQueue() {
+				ContextResource resource = new ContextResource();
+				resource.setName("jms/topic/MyQueue");
+				resource.setAuth("Container");
+				resource.setType(ActiveMQQueue.class.getName());
+				resource.setProperty("factory", JNDIReferenceFactory.class.getName());
+				resource.setProperty("physicalName", "APP.JMS.QUEUE");
+				return resource;
+			}
+
+		};
+	}
+
+}

--- a/src/main/java/sample/tomcat/jndi/config/JmsConfig.java
+++ b/src/main/java/sample/tomcat/jndi/config/JmsConfig.java
@@ -1,0 +1,103 @@
+package sample.tomcat.jndi.config;
+
+import org.apache.catalina.Container;
+import org.apache.catalina.Context;
+import org.apache.naming.ContextBindings;
+import org.springframework.boot.context.embedded.EmbeddedWebApplicationContext;
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jms.annotation.EnableJms;
+import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
+import org.springframework.jms.support.destination.DestinationResolutionException;
+import org.springframework.jms.support.destination.JndiDestinationResolver;
+import org.springframework.jndi.JndiObjectFactoryBean;
+import org.springframework.web.context.WebApplicationContext;
+
+import javax.jms.*;
+import javax.naming.NamingException;
+import java.lang.IllegalStateException;
+
+@Configuration
+@EnableJms
+public class JmsConfig {
+
+    @Bean
+    public DefaultJmsListenerContainerFactory jmsListenerContainerFactory(WebApplicationContext applicationContext) throws NamingException {
+        DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
+        factory.setConnectionFactory(connectionFactory());
+
+        // Case 1. JndiDestinationResolver - does not work, as it does an JNDI lookup in separate thread which Tomcat's JNDI
+        // treats as a different App context.
+//        factory.setDestinationResolver(new JndiDestinationResolver());
+
+        // Case 2. Potential workaround that binds the classloader of the Boot App to Tomcat's App context and
+        // its JNDI classes. Then all classes having this classloader (or ) would have been able to do JNDI lookups.
+        // BUT Spring Boot in TomcatEmbeddedServletContainer unbinds this very classloader right after bootstrap finishes.
+        // So even if we bind it here, it will get unbound by Spring Boot and we are back to Case 1.
+//        Context context = getContext(applicationContext);
+//        ContextBindings.bindClassLoader(context, context.getNamingToken(), getClass().getClassLoader());
+//        factory.setDestinationResolver(new JndiDestinationResolver());
+
+        // Case 3. Working workaround - EmbeddedTomcatJndiDestinationResolver that binds Tomcat's App context and its
+        // JNDI to the thread where the lookup happens before delegating to JndiDestinationResolver.
+        // While the workaround works fine for jmsListenerContainerFactory, any other threads that are not spawned
+        // by Tomcat and not affected by this fix (e.g. in a legacy code that can't be changed, which might be common when
+        // migrating old modular apps), would not be able to do JNDI lookups.
+        Context context = getContext(applicationContext);
+        factory.setDestinationResolver(new EmbeddedTomcatJndiDestinationResolver(context));
+
+        factory.setConcurrency("3-10");
+        return factory;
+    }
+
+    @Bean
+    public ConnectionFactory connectionFactory() throws NamingException {
+        JndiObjectFactoryBean bean = new JndiObjectFactoryBean();
+        bean.setJndiName("java:comp/env/jms/ConnectionFactory");
+        bean.setResourceRef(true);
+        bean.afterPropertiesSet();
+        return (ConnectionFactory) bean.getObject();
+    }
+
+    @Bean
+    public Queue myQueue() throws NamingException {
+        JndiObjectFactoryBean bean = new JndiObjectFactoryBean();
+        bean.setJndiName("jms/topic/MyQueue");
+        bean.setResourceRef(true);
+        bean.afterPropertiesSet();
+        return (Queue) bean.getObject();
+    }
+
+    private static class EmbeddedTomcatJndiDestinationResolver extends JndiDestinationResolver {
+        private Context context;
+
+        public EmbeddedTomcatJndiDestinationResolver(Context context) {
+            super();
+            this.context = context;
+            setResourceRef(true);
+        }
+
+        @Override
+        public Destination resolveDestinationName(Session session, String destinationName, boolean pubSubDomain) throws JMSException {
+            try {
+                ContextBindings.bindThread(context, context.getNamingToken());
+                return super.resolveDestinationName(session, destinationName, pubSubDomain);
+            } catch (NamingException e) {
+                throw new DestinationResolutionException("Destination [" + destinationName + "] not found in JNDI", e);
+            }
+        }
+    }
+
+    private Context getContext(WebApplicationContext applicationContext) {
+        EmbeddedWebApplicationContext ewac = (EmbeddedWebApplicationContext) applicationContext;
+        TomcatEmbeddedServletContainer tomcatContainer = (TomcatEmbeddedServletContainer) ewac.getEmbeddedServletContainer();
+        for (Container child : tomcatContainer.getTomcat().getHost().findChildren()) {
+            if (child instanceof Context) {
+                return (Context) child;
+            }
+        }
+        throw new IllegalStateException("The host does not contain a Context");
+    }
+
+}

--- a/src/main/java/sample/tomcat/jndi/legacycode/UnmodifiableLegacyCode.java
+++ b/src/main/java/sample/tomcat/jndi/legacycode/UnmodifiableLegacyCode.java
@@ -1,0 +1,23 @@
+package sample.tomcat.jndi.legacycode;
+
+import javax.jms.*;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+/**
+ * Let's assume this is a code in a provided library that is really needed to be reused
+ * and can't be reimplemented at the moment. We might not have access to sources
+ * or can't change it for any other reasons.
+ */
+public class UnmodifiableLegacyCode {
+    private static String JNDI_QUEUE_NAME = "java:comp/env/jms/queue/MyQueue";
+
+    /**
+     * This method will do successful JNDI lookup only if current thread or classloader is
+     * bound to Tomcat's App context and its JNDI.
+     */
+    public static Queue getMessageQueue() throws NamingException {
+        return (Queue) new InitialContext().lookup(JNDI_QUEUE_NAME);
+    }
+
+}

--- a/src/main/java/sample/tomcat/jndi/services/SampleJmsService.java
+++ b/src/main/java/sample/tomcat/jndi/services/SampleJmsService.java
@@ -1,0 +1,37 @@
+package sample.tomcat.jndi.services;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jms.annotation.JmsListener;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
+import org.springframework.stereotype.Service;
+
+import javax.jms.*;
+
+@Service
+public class SampleJmsService {
+
+    private static Log LOGGER = LogFactory.getLog(SampleJmsService.class);
+
+    @Autowired
+    private JmsTemplate jmsTemplate;
+
+    @Autowired
+    private Queue myQueue;
+
+    public void sendMessage(final String message) {
+        jmsTemplate.send(myQueue, new MessageCreator() {
+            public Message createMessage(Session session) throws JMSException {
+                return session.createTextMessage(message);
+            }
+        });
+    }
+
+    @JmsListener(destination = "jms/topic/MyQueue")
+    public void processMessage(String message) {
+        LOGGER.info("MBP got a message with text [" + message + "]");
+    }
+
+}

--- a/src/main/java/sample/tomcat/jndi/web/SampleController.java
+++ b/src/main/java/sample/tomcat/jndi/web/SampleController.java
@@ -16,32 +16,47 @@
 
 package sample.tomcat.jndi.web;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sample.tomcat.jndi.legacycode.UnmodifiableLegacyCode;
+import sample.tomcat.jndi.services.SampleJmsService;
+
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.sql.DataSource;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
-
-@Controller
+@RestController
 public class SampleController {
 
 	@Autowired
 	private DataSource dataSource;
 
+	@Autowired
+	private SampleJmsService jmsService;
+
 	@RequestMapping("/factoryBean")
-	@ResponseBody
 	public String factoryBean() {
 		return "DataSource retrieved from JNDI using JndiObjectFactoryBean: " + dataSource;
 	}
 
 	@RequestMapping("/direct")
-	@ResponseBody
 	public String direct() throws NamingException {
 		return "DataSource retrieved directly from JNDI: " +
 				new InitialContext().lookup("java:comp/env/jdbc/myDataSource");
+	}
+
+	@RequestMapping("/queueFromJndi")
+	public String queueFromJndi() throws NamingException {
+		return "JMS Queue retrieved directly from JNDI by legacy code: " +
+				UnmodifiableLegacyCode.getMessageQueue();
+	}
+
+	@RequestMapping("/message/{text}")
+	public String sendMessage(@PathVariable String text) {
+		jmsService.sendMessage(text);
+		return "message [" + text + "] sent";
 	}
 
 }

--- a/src/test/java/sample/tomcat/jndi/SampleTomcatJndiApplicationTests.java
+++ b/src/test/java/sample/tomcat/jndi/SampleTomcatJndiApplicationTests.java
@@ -24,17 +24,15 @@ import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.boot.test.TestRestTemplate;
-import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = SampleTomcatJndiApplication.class)
-@WebIntegrationTest(randomPort=true)
+@SpringBootTest(webEnvironment= SpringBootTest.WebEnvironment.RANDOM_PORT, classes = SampleTomcatJndiApplication.class)
 @DirtiesContext
 public class SampleTomcatJndiApplicationTests {
 


### PR DESCRIPTION
- added examples of using JMS setup (ActiveMQ as example) in embedded Tomcat's JNDI and using MDPs (MessageDrivenPojos);
- workaround for issues with JNDI lookups in non-Tomcat threads for JmsListenerContainerFactory in JndiDestinationResolver;